### PR TITLE
#18 Created primitive dockerfile for web build

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:16-alpine as build
+
+WORKDIR /client
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /client/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint src/**/*.{js,jsx,ts,tsx} --fix"
   },
   "eslintConfig": {
     "extends": [

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -5,12 +5,12 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement,
+  document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
+  </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  web:
+    build:
+      context: ./client
+      dockerfile: Dockerfile
+    ports:
+      - "80:80"


### PR DESCRIPTION
created a simple `Dockerfile` along with `docker-compose.yml` that supports docker for web build

sample output:
```
PS C:\Users\xcjsa\OneDrive\Desktop\CS 130\CS130-Group-Project> docker-compose up --build
[+] Building 18.9s (16/16) FINISHED                                                                                                                                     docker:default
 => [web internal] load build definition from Dockerfile                                                                                                                          0.0s
 => => transferring dockerfile: 280B                                                                                                                                              0.0s 
 => [web internal] load .dockerignore                                                                                                                                             0.0s 
 => => transferring context: 2B                                                                                                                                                   0.0s 
 => [web internal] load metadata for docker.io/library/nginx:alpine                                                                                                               1.9s 
 => [web internal] load metadata for docker.io/library/node:16-alpine                                                                                                             1.5s 
 => [web auth] library/node:pull token for registry-1.docker.io                                                                                                                   0.0s
 => [web auth] library/nginx:pull token for registry-1.docker.io                                                                                                                  0.0s
 => [web build 1/6] FROM docker.io/library/node:16-alpine@sha256:a1f9d027912b58a7c75be7716c97cfbc6d3099f3a97ed84aa490be9dee20e787                                                 0.0s
 => [web internal] load build context                                                                                                                                             2.8s 
 => => transferring context: 3.75MB                                                                                                                                               2.7s 
 => [web stage-1 1/2] FROM docker.io/library/nginx:alpine@sha256:db353d0f0c479c91bd15e01fc68ed0f33d9c4c52f3415e63332c3d0bf7a4bb77                                                 0.0s 
 => CACHED [web build 2/6] WORKDIR /client                                                                                                                                        0.0s
 => CACHED [web build 3/6] COPY package*.json ./                                                                                                                                  0.0s 
 => CACHED [web build 4/6] RUN npm install                                                                                                                                        0.0s 
 => [web build 5/6] COPY . .                                                                                                                                                      4.4s
 => [web build 6/6] RUN npm run build                                                                                                                                             8.9s 
 => CACHED [web stage-1 2/2] COPY --from=build /client/build /usr/share/nginx/html                                                                                                0.0s 
 => [web] exporting to image                                                                                                                                                      0.0s 
 => => exporting layers                                                                                                                                                           0.0s 
 => => writing image sha256:5588421dc28986045851b1f79816ac37eb91e056adfcc1cba01ade55d4a35521                                                                                      0.0s 
 => => naming to docker.io/library/cs130-group-project-web                                                                                                                        0.0s 
[+] Running 1/1
 ✔ Container cs130-group-project-web-1  Recreated                                                                                                                                 0.1s 
Attaching to cs130-group-project-web-1
cs130-group-project-web-1  | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
cs130-group-project-web-1  | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
cs130-group-project-web-1  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
cs130-group-project-web-1  | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
cs130-group-project-web-1  | 10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
cs130-group-project-web-1  | /docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
cs130-group-project-web-1  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
cs130-group-project-web-1  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
cs130-group-project-web-1  | /docker-entrypoint.sh: Configuration complete; ready for start up
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: using the "epoll" event method
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: nginx/1.25.3
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: built by gcc 12.2.1 20220924 (Alpine 12.2.1_git20220924-r10)
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: OS: Linux 5.15.90.1-microsoft-standard-WSL2
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1048576:1048576
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: start worker processes
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: start worker process 30
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: start worker process 31
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: start worker process 32
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: start worker process 33
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: start worker process 34
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: start worker process 35
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: start worker process 36
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: start worker process 37
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: start worker process 38
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: start worker process 39
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: start worker process 40
cs130-group-project-web-1  | 2023/11/10 04:29:31 [notice] 1#1: start worker process 41
cs130-group-project-web-1  | 172.18.0.1 - - [10/Nov/2023:04:33:11 +0000] "GET / HTTP/1.1" 200 661 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36" "-"
cs130-group-project-web-1  | 172.18.0.1 - - [10/Nov/2023:04:33:11 +0000] "GET /static/js/main.8c7e08fa.js HTTP/1.1" 200 143886 "http://localhost/" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36" "-"
cs130-group-project-web-1  | 172.18.0.1 - - [10/Nov/2023:04:33:11 +0000] "GET /static/css/main.f855e6bc.css HTTP/1.1" 200 779 "http://localhost/" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36" "-"
cs130-group-project-web-1  | 172.18.0.1 - - [10/Nov/2023:04:33:11 +0000] "GET /static/media/logo.6ce24c58023cc2f8fd88fe9d219db6c6.svg HTTP/1.1" 200 2632 "http://localhost/" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36" "-"
cs130-group-project-web-1  | 172.18.0.1 - - [10/Nov/2023:04:33:11 +0000] "GET /favicon.ico HTTP/1.1" 200 3870 "http://localhost/" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36" "-"
cs130-group-project-web-1  | 172.18.0.1 - - [10/Nov/2023:04:33:11 +0000] "GET /manifest.json HTTP/1.1" 200 517 "http://localhost/" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36" "-"
cs130-group-project-web-1  | 172.18.0.1 - - [10/Nov/2023:04:33:11 +0000] "GET /logo192.png HTTP/1.1" 200 5347 "http://localhost/" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36" "-"
```